### PR TITLE
Prettify vimrc

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -5,6 +5,17 @@ vim:
     syntax: 'on'
     colors: desert
 
+    # Config options can be nested
+    ia:
+      marco: macro
+
+    autocmd:
+      FileType:
+        sls: 'setlocal tabstop=2 softtabstop=2 shitfwidth=2'
+      BufRead,BufNewFile:
+        /etc/salt/*.conf: 'set filetype=sls'
+        /srv/*.map: 'set filetype=sls'
+
   settings:
     et:
     cin:

--- a/vim/files/vimrc
+++ b/vim/files/vimrc
@@ -42,24 +42,33 @@ let {{ parameter }} = {{ value }}
 {{ set_config('runtime!', 'debian.vim') }}
 {% endif -%}
 
+{%- if config %}
 {% for parameter in config -%}
 {{ set_config(parameter) }}
-{% endfor -%}
+{%- endfor %}
+{% endif -%}
 
+{%- if settings %}
 {% for parameter in settings -%}
 {{ set_setting(parameter) }}
-{% endfor -%}
+{%- endfor %}
+{% endif -%}
 
+{%- if mappings %}
 {% for parameter in mappings -%}
 {{ set_mapping(parameter) }}
-{% endfor -%}
+{%- endfor %}
+{% endif -%}
 
+{%- if lets %}
 {% for parameter in lets -%}
 {{ set_let(parameter) }}
-{% endfor -%}
+{%- endfor %}
+{% endif -%}
 
-{% if allow_localrc == True -%}
+{%- if allow_localrc == True %}
 if filereadable("{{ config_root }}/vimrc.local")
     source {{ config_root }}/vimrc.local
 endif
-{% endif %}
+{% endif -%}
+

--- a/vim/files/vimrc
+++ b/vim/files/vimrc
@@ -4,11 +4,19 @@
 {% set lets = salt['pillar.get']('vim:lets', {}) -%}
 {% set allow_localrc = salt['pillar.get']('vim:allow_localrc', {}) -%}
 
-{% macro set_config(parameter, default=None) -%}
-{% set value = config.get(parameter, default) -%}
-{% if value is not none -%}
-{{ parameter }} {{ value }}
+{% macro set_config(config, prefix='') -%}
+{% for parameter in config | sort -%}
+{% set value = config.get(parameter) -%}
+{% if value is mapping -%}
+{{ set_config(value, prefix=prefix+parameter+' ') }}
+{%- elif value is sequence and value is not string -%}
+{% for item in value -%}
+{{ prefix }}{{ parameter }} {{ item }}
+{% endfor -%}
+{%- elif value is not none -%}
+{{ prefix }}{{ parameter }} {{ value }}
 {% endif -%}
+{% endfor -%}
 {% endmacro -%}
 
 {% macro set_setting(parameter, default=None) -%}
@@ -34,34 +42,32 @@ let {{ parameter }} = {{ value }}
 {% endif -%}
 {% endmacro -%}
 
-{% if grains['os'] == 'Arch' -%}
+{%- if grains['os'] == 'Arch' -%}
 {{ set_config('runtime!', 'archlinux.vim') }}
 {% endif -%}
 
-{% if grains['os'] == 'Debian' -%}
+{%- if grains['os'] == 'Debian' -%}
 {{ set_config('runtime!', 'debian.vim') }}
 {% endif -%}
 
-{%- if config %}
-{% for parameter in config -%}
-{{ set_config(parameter) }}
-{%- endfor %}
+{%- if config -%}
+{{ set_config(config) }}
 {% endif -%}
 
-{%- if settings %}
-{% for parameter in settings -%}
+{%- if settings -%}
+{% for parameter in settings | sort -%}
 {{ set_setting(parameter) }}
 {%- endfor %}
 {% endif -%}
 
-{%- if mappings %}
-{% for parameter in mappings -%}
+{%- if mappings -%}
+{% for parameter in mappings | sort -%}
 {{ set_mapping(parameter) }}
 {%- endfor %}
 {% endif -%}
 
-{%- if lets %}
-{% for parameter in lets -%}
+{%- if lets -%}
+{% for parameter in lets | sort -%}
 {{ set_let(parameter) }}
 {%- endfor %}
 {% endif -%}


### PR DESCRIPTION
This PR adds support for nesting config options in the pillar and improves the readability of the rendered `vimrc` file.
An example of nesting the config options was added to the `pillar.example` as well.
The rendered `vimrc` will not contain extra empty lines and all options are sorted by name.

`vimrc` settings before:
```
set incsearch                    
                                 
set number                       
                                 
set ignorecase                   
                                 
set wildmenu                     
                                 
set expandtab                    
                                 
set autoindent                   
                                 
set hlsearch                     
                                 
set shiftwidth=4                 
                                 
set laststatus=2                 
                                 
set softtabstop=4                
                                 
set showmatch                    
                                 
set backspace=indent,eol,start   
                                 
set wildmode=full                

set nocompatible                 

set diffopt=filler,iwhite        

set undodir=/tmp                 

set smartcase                    

set backupdir=/tmp/              

set undofile                     

set magic                        

set wildignore+=*.0,*~,.lo       

set tabstop=4                    

set updatecount=100

set ttyfast

set matchpairs+=<:>
 

```

`vimrc` settings after:
```                                                    
set autoindent                                                               
set backspace=indent,eol,start                                               
set backupdir=/tmp/                                                          
set diffopt=filler,iwhite                                                    
set expandtab                                                                
set hlsearch                                                                 
set ignorecase                                                               
set incsearch                                                                
set laststatus=2                                                             
set magic                                                                    
set matchpairs+=<:>                                                          
set nocompatible                                                             
set number                                                                   
set shiftwidth=4                                                             
set showmatch                                                                
set smartcase                                                                
set softtabstop=4                                                            
set tabstop=4                                                                
set ttyfast                                                                  
set undodir=/tmp                                                             
set undofile                                                                 
set updatecount=100                                                          
set wildignore+=*.0,*~,.lo                                                   
set wildmenu                                                                 
set wildmode=full                                                            
```